### PR TITLE
Allow the filter agent's bind address to be specified

### DIFF
--- a/ssh-agent-filter.C
+++ b/ssh-agent-filter.C
@@ -196,6 +196,7 @@ int make_listen_sock () {
 void parse_cmdline (int const argc, char const * const * const argv) {
 	po::options_description opts{"OPTIONS"};
 	opts.add_options()
+		("bind,b",			po::value(&path),		"bind address specified by filesystem path")
 		("all-confirmed,A",		po::bool_switch(&all_confirmed),"allow all other keys with confirmation")
 		("comment,c",			po::value(&allowed_comment),	"key specified by comment")
 		("comment-confirmed,C",		po::value(&confirmed_comment),	"key specified by comment, with confirmation")
@@ -518,11 +519,11 @@ void sighandler (int sig) {
 }
 
 int main (int const argc, char const * const * const argv) {
+	path = fs::current_path() / ("agent." + std::to_string(getpid()));
 	parse_cmdline(argc, argv);
 	
 	setup_filters();
 
-	path = fs::current_path() / ("agent." + std::to_string(getpid()));
 	int listen_sock = make_listen_sock();
 
 	if (not debug) {

--- a/ssh-agent-filter.bash-completion
+++ b/ssh-agent-filter.bash-completion
@@ -23,9 +23,13 @@ _ssh-agent-filter () {
 
 	_quote_readline_by_ref "$cur" cur
 	
-	opts="--all-confirmed --comment --comment-confirmed --debug --fingerprint --fingerprint-confirmed --help --key --key-confirmed --name --version"
+	opts="--all-confirmed --bind --comment --comment-confirmed --debug --fingerprint --fingerprint-confirmed --help --key --key-confirmed --name --version"
 	
 	case "$prev" in
+		-b|--bind)
+			COMPREPLY=()
+			return 0
+			;;
 		-c|--comment|-C|--comment-confirmed)
 			# hm, key comments might contain anything, how can I quote them ?
 			local comments="$(ssh-add -L | cut -d\  -f3- )"
@@ -52,7 +56,7 @@ _ssh-agent-filter () {
 	
 	COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
 	return 0
-} && complete -F _ssh-agent-filter ssh-agent-filter
+} && complete -o default -F _ssh-agent-filter ssh-agent-filter
 
 _ssh-agent-filter_have_dash-dash () {
 	local i


### PR DESCRIPTION
Add an additional command-line option (-a / --bind-address) that can be used to
specify an alternate path for the filter agent's UNIX domain socket.
