### PR TITLE
Use realpath instead of readlink -f in afssh

### DIFF
--- a/afssh
+++ b/afssh
@@ -52,7 +52,7 @@ fi
 declare -a agent_filter_args
 
 if [ -x "${BASH_SOURCE%/*}/ssh-agent-filter" ]; then
-	SAF=$(readlink -f "${BASH_SOURCE%/*}/ssh-agent-filter")
+	SAF=$(realpath "${BASH_SOURCE%/*}/ssh-agent-filter")
 else
 	SAF=$(which ssh-agent-filter)
 fi


### PR DESCRIPTION
On MacOSX the pre-installed readlink binary doesn't know about the `-f`
argument, a GNU extension. Additionally, installing the commonly used
`coreutils` package from Homebrew will create a binary named `greadlink`
instead of masking the pre-installed one. However `coreutils` does
create a `realpath` binary (since MacOSX doesn't have that one at all)
which is pretty much equivalent to `readlink -f`. So with this change
`ssh-agent-filter` will work out of the box in many cases.