### PR TITLE
Use realpath instead of readlink -f in afssh

### DIFF
--- a/afssh
+++ b/afssh
@@ -51,6 +51,12 @@ fi
 
 declare -a agent_filter_args
 
+if ! type -P realpath >/dev/null 2>&1  ; then
+    function realpath () {
+       perl -mCwd -e 'print Cwd::abs_path($_), "\n" foreach @ARGV;' $@
+    }
+fi
+
 if [ -x "${BASH_SOURCE%/*}/ssh-agent-filter" ]; then
 	SAF=$(realpath "${BASH_SOURCE%/*}/ssh-agent-filter")
 else

--- a/afssh
+++ b/afssh
@@ -52,7 +52,7 @@ fi
 declare -a agent_filter_args
 
 if [ -x "${BASH_SOURCE%/*}/ssh-agent-filter" ]; then
-	SAF=$(readlink -f "${BASH_SOURCE%/*}/ssh-agent-filter")
+	SAF=$(realpath "${BASH_SOURCE%/*}/ssh-agent-filter")
 else
 	SAF=$(which ssh-agent-filter)
 fi


### PR DESCRIPTION
Reopened #5 with a fallback implementation that should work across all UNIX variants (that have perl).
