### PR TITLE
Do a static build by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ CXXFLAGS ?= -g -O2 -Wall -Wold-style-cast
 
 CPPFLAGS += -D_FILE_OFFSET_BITS=64
 CXXFLAGS += -std=c++11
-LDLIBS = -lstdc++ -lboost_program_options -lboost_filesystem -lboost_system -lboost_iostreams -lnettle -lpthread
+LIBDIR ?= /usr/local/lib
+LDLIBS = -lstdc++ $(LIBDIR)/libboost_program_options.a $(LIBDIR)/libboost_filesystem.a $(LIBDIR)/libboost_system.a $(LIBDIR)/libboost_iostreams.a $(LIBDIR)/libnettle.a -lpthread
 
 all: ssh-agent-filter.1 afssh.1 ssh-askpass-noinput.1
 


### PR DESCRIPTION
Boost is not a meaningful dependency for end users, thus compile boost and nettle statically, for easy distribution.